### PR TITLE
Switch Calloc,Free to R_Calloc,R_Free to support STRICT_R_HEADERS

### DIFF
--- a/src/mine_int.cpp
+++ b/src/mine_int.cpp
@@ -91,7 +91,7 @@ mine_matrix *rMattomine(NumericMatrix x)
 {
   mine_matrix *X;
   
-  X = (mine_matrix *) Calloc(1, mine_matrix);
+  X = (mine_matrix *) R_Calloc(1, mine_matrix);
   X->data=REAL(x);
   X->n=x.ncol();
   X->m=x.nrow();
@@ -465,7 +465,7 @@ NumericVector mictools_null(NumericMatrix x, double alpha=9, double C=5, int npe
   mine_score *minescore;
   
   /* Set parameters for mine computation */
-  param = (mine_parameter *) Calloc(1,mine_parameter);
+  param = (mine_parameter *) R_Calloc(1,mine_parameter);
   param->alpha=alpha;
   param->c=C;
   param->est=1; // est == "mic_e"
@@ -477,7 +477,7 @@ NumericVector mictools_null(NumericMatrix x, double alpha=9, double C=5, int npe
   }
   
   /* Set up mine problem */
-  prob = (mine_problem *) Calloc(1,mine_problem);
+  prob = (mine_problem *) R_Calloc(1,mine_problem);
   prob->n=n;
   
   /* set seed */
@@ -507,8 +507,8 @@ NumericVector mictools_null(NumericMatrix x, double alpha=9, double C=5, int npe
   }
   
   /* Free memory */
-  Free(param);
-  Free(prob);
+  R_Free(param);
+  R_Free(prob);
   
   return(restic);
 }


### PR DESCRIPTION
Dear Samantha, dear minerva team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in one file) Calloc and Free which go away (for the 'safer' R_Calloc and R_Free less likely to clash with another definition) when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes these two in a handful of places. 

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.